### PR TITLE
Masking in subs dt

### DIFF
--- a/R/subsDT.R
+++ b/R/subsDT.R
@@ -65,11 +65,12 @@ subsDT <- function(x, dict,
         DT <- data.table(ID = getValues(x))
         names(DT) <- by
         for (i in 1:nx) {
-            vals <- dict[DT[, ..i], , on = by[i]][[which[i]]]
+            vals <- dict[DT[, ..i], , on = by[i], which = TRUE]
+            nn <- is.na(vals)
             if (isFALSE(subsWithNA)) {
-                nn <- is.na(vals)
                 vals[nn] <- DT[[i]][nn]
             }
+            vals[!nn] <- dict[DT[, ..i], , on = by[i], nomatch = NULL][[which[i]]]
             ll[[i]] <- vals
         }
         vals <- as.matrix(as.data.table(ll))
@@ -94,11 +95,12 @@ subsDT <- function(x, dict,
                                             nrows = tr$nrows[i]))
             names(DT) <- by
             for (j in 1:nx) {
-                vals <- dict[DT[, ..j], , on = by[j]][[which[j]]]
+                vals <- dict[DT[, ..j], , on = by[j], which = TRUE]
+                nn <- is.na(vals)
                 if (isFALSE(subsWithNA)) {
-                    nn <- is.na(vals)
                     vals[nn] <- DT[[j]][nn]
                 }
+                vals[!nn] <- dict[DT[, ..j], , on = by[j], nomatch = NULL][[which[i]]]
                 ll[[j]] <- vals
             }
             vals <- as.matrix(as.data.table(ll))

--- a/R/subsDT.R
+++ b/R/subsDT.R
@@ -100,7 +100,7 @@ subsDT <- function(x, dict,
                 if (isFALSE(subsWithNA)) {
                     vals[nn] <- DT[[j]][nn]
                 }
-                vals[!nn] <- dict[DT[, ..j], , on = by[j], nomatch = NULL][[which[i]]]
+                vals[!nn] <- dict[DT[, ..j], , on = by[j], nomatch = NULL][[which[j]]]
                 ll[[j]] <- vals
             }
             vals <- as.matrix(as.data.table(ll))
@@ -112,4 +112,3 @@ subsDT <- function(x, dict,
         return(out)
     }
 }
-


### PR DESCRIPTION
Here is the patch I suggested in the Issue (https://github.com/JoshOBrien/rasterDT/issues/1). It doesn't appear to make the function less efficient, and it still works for multi-row `dict` objects when one of the rows specifies to replace a value to NA and another row specifies a replacement of a different original value for a non-NA.

One consideration I couldn't quite figure out is whether this patch requires more memory, which might mean that Line 61 where the `raster::canProcessInMemory()` function is run would need a different value for the `n=` argument (for instance, bumping its current value from 3 to 4 to reflect that another copy of the raster values is required to be held in RAM in order to process in memory.)